### PR TITLE
Upgrade to Stackage resolver LTS-22.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup latest stack
-        uses: actions/setup-haskell@v1
+        uses: haskell/actions/setup@v2
         with:
           enable-stack: true
           stack-version: 'latest'

--- a/examples/erc20/example-erc20.cabal
+++ b/examples/erc20/example-erc20.cabal
@@ -1,0 +1,38 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.36.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           example-erc20
+version:        0.0.0.0
+synopsis:       ERC20 token example.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+executable example-erc20
+  main-is: Main.hs
+  other-modules:
+      ERC20
+      Paths_example_erc20
+  hs-source-dirs:
+      ./
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , data-default
+    , microlens
+    , text
+    , web3
+    , web3-ethereum
+  default-language: Haskell2010

--- a/examples/polkadot/example-polkadot.cabal
+++ b/examples/polkadot/example-polkadot.cabal
@@ -1,0 +1,34 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.36.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           example-polkadot
+version:        0.0.0.0
+synopsis:       Polkadot API example.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+executable example-polkadot
+  main-is: Main.hs
+  other-modules:
+      Paths_example_polkadot
+  hs-source-dirs:
+      ./
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , web3-polkadot
+    , web3-provider
+  default-language: Haskell2010

--- a/examples/scale/example-scale.cabal
+++ b/examples/scale/example-scale.cabal
@@ -1,0 +1,35 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.36.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           example-scale
+version:        0.0.0.0
+synopsis:       SCALE codec example.
+category:       Network
+homepage:       https://github.com/airalab/hs-web3#readme
+bug-reports:    https://github.com/airalab/hs-web3/issues
+author:         Aleksandr Krupenkin
+maintainer:     mail@akru.me
+copyright:      (c) Aleksandr Krupenkin 2016-2021
+license:        Apache-2.0
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/airalab/hs-web3
+
+executable example-scale
+  main-is: Main.hs
+  other-modules:
+      Paths_example_scale
+  hs-source-dirs:
+      ./
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , generics-sop
+    , memory-hexstring
+    , scale
+  default-language: Haskell2010

--- a/packages/bignum/package.yaml
+++ b/packages/bignum/package.yaml
@@ -11,9 +11,9 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.16
+- base                 >4.11 && <4.19
 - scale                >=1.0 && <1.1
-- memory               >0.14 && <0.17
+- memory               >0.14 && <0.19
 - memory-hexstring     >=1.0 && <1.1
 - cereal               >0.5  && <0.6
 - wide-word            >0.1  && <0.2
@@ -51,14 +51,14 @@ tests:
   tests:
     main:             Spec.hs
     source-dirs:
-    - tests 
+    - tests
     - src
     dependencies:
-    - memory-hexstring     >=1.0 && <1.1 
+    - memory-hexstring     >=1.0 && <1.1
     - hspec-expectations   >=0.8.2  && <0.9
-    - hspec-discover       >=2.4.4  && <2.9
+    - hspec-discover       >=2.4.4  && <2.12
     - hspec-contrib        >=0.4.0  && <0.6
-    - hspec                >=2.4.4  && <2.9
+    - hspec                >=2.4.4  && <2.12
     ghc-options:
     - -threaded
     - -rtsopts

--- a/packages/bignum/web3-bignum.cabal
+++ b/packages/bignum/web3-bignum.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -31,9 +31,9 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      base >4.11 && <4.16
+      base >4.11 && <4.19
     , cereal >0.5 && <0.6
-    , memory >0.14 && <0.17
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
     , scale ==1.0.*
     , wide-word >0.1 && <0.2
@@ -51,13 +51,13 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >4.11 && <4.16
+      base >4.11 && <4.19
     , cereal >0.5 && <0.6
-    , hspec >=2.4.4 && <2.9
+    , hspec >=2.4.4 && <2.12
     , hspec-contrib >=0.4.0 && <0.6
-    , hspec-discover >=2.4.4 && <2.9
+    , hspec-discover >=2.4.4 && <2.12
     , hspec-expectations >=0.8.2 && <0.9
-    , memory >0.14 && <0.17
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
     , scale ==1.0.*
     , wide-word >0.1 && <0.2

--- a/packages/crypto/package.yaml
+++ b/packages/crypto/package.yaml
@@ -15,15 +15,15 @@ extra-source-files:
 - src/cbits/xxhash.c
 
 dependencies:
-- base                 >4.11 && <4.16
-- text                 >1.2  && <1.3
+- base                 >4.11 && <4.19
+- text                 >1.2  && <2.1
 - aeson                >1.2  && <2.2
-- memory               >0.14 && <0.17
-- vector               >0.12 && <0.13
+- memory               >0.14 && <0.19
+- vector               >0.12 && <0.14
 - containers           >0.6  && <0.7
 - uuid-types           >1.0  && <1.1
-- cryptonite           >0.22 && <0.30
-- bytestring           >0.10 && <0.11
+- cryptonite           >0.22 && <0.31
+- bytestring           >0.10 && <0.12
 - memory-hexstring     >=1.0 && <1.1
 
 ghc-options:
@@ -67,9 +67,9 @@ tests:
     c-sources:    src/cbits/xxhash.c
     dependencies:
     - hspec-expectations   >=0.8.2  && <0.9
-    - hspec-discover       >=2.4.4  && <2.9
+    - hspec-discover       >=2.4.4  && <2.12
     - hspec-contrib        >=0.4.0  && <0.6
-    - hspec                >=2.4.4  && <2.9
+    - hspec                >=2.4.4  && <2.12
     ghc-options:
     - -threaded
     - -rtsopts

--- a/packages/crypto/package.yaml
+++ b/packages/crypto/package.yaml
@@ -15,16 +15,16 @@ extra-source-files:
 - src/cbits/xxhash.c
 
 dependencies:
-- base                 >4.11 && <4.19
-- text                 >1.2  && <2.1
-- aeson                >1.2  && <2.2
-- memory               >0.14 && <0.19
-- vector               >0.12 && <0.14
-- containers           >0.6  && <0.7
-- uuid-types           >1.0  && <1.1
-- cryptonite           >0.22 && <0.31
-- bytestring           >0.10 && <0.12
-- memory-hexstring     >=1.0 && <1.1
+- base                 >4.11  && <4.19
+- text                 >1.2   && <2.1
+- aeson                >1.2   && <2.2
+- memory               >0.14  && <0.19
+- vector               >0.12  && <0.14
+- containers           >0.6   && <0.7
+- uuid-types           >1.0   && <1.1
+- crypton              >=0.31 && <1.0
+- bytestring           >0.10  && <0.12
+- memory-hexstring     >=1.0  && <1.1
 
 ghc-options:
 - -funbox-strict-fields

--- a/packages/crypto/web3-crypto.cabal
+++ b/packages/crypto/web3-crypto.cabal
@@ -51,7 +51,7 @@ library
     , base >4.11 && <4.19
     , bytestring >0.10 && <0.12
     , containers >0.6 && <0.7
-    , cryptonite >0.22 && <0.31
+    , crypton >=0.31 && <1.0
     , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
     , text >1.2 && <2.1
@@ -92,7 +92,7 @@ test-suite tests
     , base >4.11 && <4.19
     , bytestring >0.10 && <0.12
     , containers >0.6 && <0.7
-    , cryptonite >0.22 && <0.31
+    , crypton >=0.31 && <1.0
     , hspec >=2.4.4 && <2.12
     , hspec-contrib >=0.4.0 && <0.6
     , hspec-discover >=2.4.4 && <2.12

--- a/packages/crypto/web3-crypto.cabal
+++ b/packages/crypto/web3-crypto.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -48,15 +48,15 @@ library
       src/cbits/xxhash.c
   build-depends:
       aeson >1.2 && <2.2
-    , base >4.11 && <4.16
-    , bytestring >0.10 && <0.11
+    , base >4.11 && <4.19
+    , bytestring >0.10 && <0.12
     , containers >0.6 && <0.7
-    , cryptonite >0.22 && <0.30
-    , memory >0.14 && <0.17
+    , cryptonite >0.22 && <0.31
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
-    , text >1.2 && <1.3
+    , text >1.2 && <2.1
     , uuid-types >1.0 && <1.1
-    , vector >0.12 && <0.13
+    , vector >0.12 && <0.14
   default-language: Haskell2010
 
 test-suite tests
@@ -89,17 +89,17 @@ test-suite tests
       src/cbits/xxhash.c
   build-depends:
       aeson >1.2 && <2.2
-    , base >4.11 && <4.16
-    , bytestring >0.10 && <0.11
+    , base >4.11 && <4.19
+    , bytestring >0.10 && <0.12
     , containers >0.6 && <0.7
-    , cryptonite >0.22 && <0.30
-    , hspec >=2.4.4 && <2.9
+    , cryptonite >0.22 && <0.31
+    , hspec >=2.4.4 && <2.12
     , hspec-contrib >=0.4.0 && <0.6
-    , hspec-discover >=2.4.4 && <2.9
+    , hspec-discover >=2.4.4 && <2.12
     , hspec-expectations >=0.8.2 && <0.9
-    , memory >0.14 && <0.17
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
-    , text >1.2 && <1.3
+    , text >1.2 && <2.1
     , uuid-types >1.0 && <1.1
-    , vector >0.12 && <0.13
+    , vector >0.12 && <0.14
   default-language: Haskell2010

--- a/packages/ethereum/package.yaml
+++ b/packages/ethereum/package.yaml
@@ -11,25 +11,25 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.16
-- text                 >1.2  && <1.3
-- vinyl                >0.5  && <0.14
+- base                 >4.11 && <4.19
+- text                 >1.2  && <2.1
+- vinyl                >0.5  && <0.15
 - aeson                >1.2  && <2.2
 - aeson-casing         >=0.2 && <0.3
 - tagged               >0.8  && <0.9
-- memory               >0.14 && <0.17
+- memory               >0.14 && <0.19
 - relapse              >=1.0 && <2.0
-- OneTuple             >0.2  && <0.4
+- OneTuple             >0.2  && <0.5
 - machines             >0.6  && <0.8
 - microlens            >0.4  && <0.5
-- bytestring           >0.10 && <0.11
+- bytestring           >0.10 && <0.12
 - exceptions           >0.8  && <0.11
 - generics-sop         >0.3  && <0.6
 - data-default         >0.7  && <0.8
-- transformers         >0.5  && <0.6
-- microlens-aeson      >2.2  && <2.5
-- template-haskell     >2.11 && <2.18
-- mtl                  >2.2  && <2.3
+- transformers         >0.5  && <0.7
+- microlens-aeson      >2.2  && <2.6
+- template-haskell     >2.11 && <2.21
+- mtl                  >2.2  && <2.4
 - web3-crypto          >=1.0 && <1.1
 - web3-solidity        >=1.0 && <1.1
 - memory-hexstring     >=1.0 && <1.1
@@ -72,9 +72,9 @@ tests:
     - src
     dependencies:
     - hspec-expectations   >=0.8.2  && <0.9
-    - hspec-discover       >=2.4.4  && <2.9
+    - hspec-discover       >=2.4.4  && <2.12
     - hspec-contrib        >=0.4.0  && <0.6
-    - hspec                >=2.4.4  && <2.9
+    - hspec                >=2.4.4  && <2.12
     ghc-options:
     - -threaded
     - -rtsopts

--- a/packages/ethereum/web3-ethereum.cabal
+++ b/packages/ethereum/web3-ethereum.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -56,27 +56,27 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      OneTuple >0.2 && <0.4
+      OneTuple >0.2 && <0.5
     , aeson >1.2 && <2.2
     , aeson-casing ==0.2.*
-    , base >4.11 && <4.16
-    , bytestring >0.10 && <0.11
+    , base >4.11 && <4.19
+    , bytestring >0.10 && <0.12
     , data-default >0.7 && <0.8
     , exceptions >0.8 && <0.11
     , generics-sop >0.3 && <0.6
     , jsonrpc-tinyclient ==1.0.*
     , machines >0.6 && <0.8
-    , memory >0.14 && <0.17
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
-    , microlens-aeson >2.2 && <2.5
-    , mtl >2.2 && <2.3
+    , microlens-aeson >2.2 && <2.6
+    , mtl >2.2 && <2.4
     , relapse >=1.0 && <2.0
     , tagged >0.8 && <0.9
-    , template-haskell >2.11 && <2.18
-    , text >1.2 && <1.3
-    , transformers >0.5 && <0.6
-    , vinyl >0.5 && <0.14
+    , template-haskell >2.11 && <2.21
+    , text >1.2 && <2.1
+    , transformers >0.5 && <0.7
+    , vinyl >0.5 && <0.15
     , web3-crypto ==1.0.*
     , web3-solidity ==1.0.*
   default-language: Haskell2010
@@ -121,31 +121,31 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      OneTuple >0.2 && <0.4
+      OneTuple >0.2 && <0.5
     , aeson >1.2 && <2.2
     , aeson-casing ==0.2.*
-    , base >4.11 && <4.16
-    , bytestring >0.10 && <0.11
+    , base >4.11 && <4.19
+    , bytestring >0.10 && <0.12
     , data-default >0.7 && <0.8
     , exceptions >0.8 && <0.11
     , generics-sop >0.3 && <0.6
-    , hspec >=2.4.4 && <2.9
+    , hspec >=2.4.4 && <2.12
     , hspec-contrib >=0.4.0 && <0.6
-    , hspec-discover >=2.4.4 && <2.9
+    , hspec-discover >=2.4.4 && <2.12
     , hspec-expectations >=0.8.2 && <0.9
     , jsonrpc-tinyclient ==1.0.*
     , machines >0.6 && <0.8
-    , memory >0.14 && <0.17
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
-    , microlens-aeson >2.2 && <2.5
-    , mtl >2.2 && <2.3
+    , microlens-aeson >2.2 && <2.6
+    , mtl >2.2 && <2.4
     , relapse >=1.0 && <2.0
     , tagged >0.8 && <0.9
-    , template-haskell >2.11 && <2.18
-    , text >1.2 && <1.3
-    , transformers >0.5 && <0.6
-    , vinyl >0.5 && <0.14
+    , template-haskell >2.11 && <2.21
+    , text >1.2 && <2.1
+    , transformers >0.5 && <0.7
+    , vinyl >0.5 && <0.15
     , web3-crypto ==1.0.*
     , web3-solidity ==1.0.*
   default-language: Haskell2010

--- a/packages/hexstring/memory-hexstring.cabal
+++ b/packages/hexstring/memory-hexstring.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -35,10 +35,10 @@ library
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
       aeson >1.2 && <2.2
-    , base >4.11 && <4.16
-    , bytestring >0.10 && <0.11
-    , memory >0.14 && <0.17
+    , base >4.11 && <4.19
+    , bytestring >0.10 && <0.12
+    , memory >0.14 && <0.19
     , scale ==1.0.*
-    , template-haskell >2.11 && <2.18
-    , text >1.2 && <1.3
+    , template-haskell >2.11 && <2.21
+    , text >1.2 && <2.1
   default-language: Haskell2010

--- a/packages/hexstring/package.yaml
+++ b/packages/hexstring/package.yaml
@@ -11,12 +11,12 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.16
-- text                 >1.2  && <1.3
+- base                 >4.11 && <4.19
+- text                 >1.2  && <2.1
 - aeson                >1.2  && <2.2
-- memory               >0.14 && <0.17
-- bytestring           >0.10 && <0.11
-- template-haskell     >2.11 && <2.18
+- memory               >0.14 && <0.19
+- bytestring           >0.10 && <0.12
+- template-haskell     >2.11 && <2.21
 - scale                >=1.0 && <1.1
 
 ghc-options:

--- a/packages/ipfs/package.yaml
+++ b/packages/ipfs/package.yaml
@@ -11,18 +11,18 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.16
-- mtl                  >2.2  && <2.3
-- tar                  >0.4  && <0.6  
-- text                 >1.2  && <1.3
+- base                 >4.11 && <4.19
+- mtl                  >2.2  && <2.4
+- tar                  >0.4  && <0.6
+- text                 >1.2  && <2.1
 - aeson                >1.2  && <2.2
-- servant              >0.12 && <0.20
-- http-media           >0.6  && <0.8.1
-- bytestring           >0.10 && <0.11
-- http-types           >0.11 && <0.14 
+- servant              >0.12 && <0.21
+- http-media           >0.6  && <0.9
+- bytestring           >0.10 && <0.12
+- http-types           >0.11 && <0.14
 - http-client          >0.5  && <0.8
-- servant-client       >0.12 && <0.20
-- unordered-containers >0.1  && <0.3 
+- servant-client       >0.12 && <0.21
+- unordered-containers >0.1  && <0.3
 
 ghc-options:
 - -funbox-strict-fields

--- a/packages/ipfs/web3-ipfs.cabal
+++ b/packages/ipfs/web3-ipfs.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -54,15 +54,15 @@ library
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
       aeson >1.2 && <2.2
-    , base >4.11 && <4.16
-    , bytestring >0.10 && <0.11
+    , base >4.11 && <4.19
+    , bytestring >0.10 && <0.12
     , http-client >0.5 && <0.8
-    , http-media >0.6 && <0.8.1
+    , http-media >0.6 && <0.9
     , http-types >0.11 && <0.14
-    , mtl >2.2 && <2.3
-    , servant >0.12 && <0.20
-    , servant-client >0.12 && <0.20
+    , mtl >2.2 && <2.4
+    , servant >0.12 && <0.21
+    , servant-client >0.12 && <0.21
     , tar >0.4 && <0.6
-    , text >1.2 && <1.3
+    , text >1.2 && <2.1
     , unordered-containers >0.1 && <0.3
   default-language: Haskell2010

--- a/packages/jsonrpc/jsonrpc-tinyclient.cabal
+++ b/packages/jsonrpc/jsonrpc-tinyclient.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -32,13 +32,13 @@ library
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
       aeson >1.2 && <2.2
-    , base >4.11 && <4.16
-    , bytestring >0.10 && <0.11
+    , base >4.11 && <4.19
+    , bytestring >0.10 && <0.12
     , exceptions >0.8 && <0.11
     , http-client >0.5 && <0.8
     , http-client-tls >0.3 && <0.4
-    , mtl >2.2 && <2.3
+    , mtl >2.2 && <2.4
     , random >1.0 && <1.3
-    , text >1.2 && <1.3
+    , text >1.2 && <2.1
     , websockets >0.10 && <0.13
   default-language: Haskell2010

--- a/packages/jsonrpc/package.yaml
+++ b/packages/jsonrpc/package.yaml
@@ -11,16 +11,16 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.16
-- text                 >1.2  && <1.3
+- base                 >4.11 && <4.19
+- text                 >1.2  && <2.1
 - aeson                >1.2  && <2.2
 - random               >1.0  && <1.3
-- bytestring           >0.10 && <0.11
+- bytestring           >0.10 && <0.12
 - exceptions           >0.8  && <0.11
 - websockets           >0.10 && <0.13
 - http-client          >0.5  && <0.8
 - http-client-tls      >0.3  && <0.4
-- mtl                  >2.2  && <2.3
+- mtl                  >2.2  && <2.4
 
 ghc-options:
 - -funbox-strict-fields

--- a/packages/polkadot/package.yaml
+++ b/packages/polkadot/package.yaml
@@ -11,26 +11,26 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- mtl                  >2.2  && <2.4
-- base                 >4.11 && <4.19
-- text                 >1.2  && <2.1
-- aeson                >1.2  && <2.2
-- scale                >=1.0 && <1.1
-- parsec               >3.0  && <3.2
-- memory               >0.14 && <0.19
-- microlens            >0.4  && <0.5
-- containers           >0.6  && <0.7
-- cryptonite           >0.22 && <0.31
-- bytestring           >0.10 && <0.12
-- base58-bytestring    >=0.1 && <0.2
-- animalcase           >0.1  && <0.2
-- generics-sop         >0.3  && <0.6
-- microlens-th         >0.4  && <0.5
-- microlens-mtl        >0.2  && <0.3
-- web3-crypto          >=1.0 && <1.1
-- web3-bignum          >=1.0 && <1.1
-- jsonrpc-tinyclient   >=1.0 && <1.1
-- memory-hexstring     >=1.0 && <1.1
+- mtl                  >2.2   && <2.4
+- base                 >4.11  && <4.19
+- text                 >1.2   && <2.1
+- aeson                >1.2   && <2.2
+- scale                >=1.0  && <1.1
+- parsec               >3.0   && <3.2
+- memory               >0.14  && <0.19
+- microlens            >0.4   && <0.5
+- containers           >0.6   && <0.7
+- crypton              >=0.31 && <1.0
+- bytestring           >0.10  && <0.12
+- base58-bytestring    >=0.1  && <0.2
+- animalcase           >0.1   && <0.2
+- generics-sop         >0.3   && <0.6
+- microlens-th         >0.4   && <0.5
+- microlens-mtl        >0.2   && <0.3
+- web3-crypto          >=1.0  && <1.1
+- web3-bignum          >=1.0  && <1.1
+- jsonrpc-tinyclient   >=1.0  && <1.1
+- memory-hexstring     >=1.0  && <1.1
 
 ghc-options:
 - -funbox-strict-fields

--- a/packages/polkadot/package.yaml
+++ b/packages/polkadot/package.yaml
@@ -11,17 +11,17 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- mtl                  >2.2  && <2.3
-- base                 >4.11 && <4.16
-- text                 >1.2  && <1.3
-- aeson                >1.2  && <2.1
+- mtl                  >2.2  && <2.4
+- base                 >4.11 && <4.19
+- text                 >1.2  && <2.1
+- aeson                >1.2  && <2.2
 - scale                >=1.0 && <1.1
 - parsec               >3.0  && <3.2
-- memory               >0.14 && <0.17
+- memory               >0.14 && <0.19
 - microlens            >0.4  && <0.5
 - containers           >0.6  && <0.7
-- cryptonite           >0.22 && <0.30
-- bytestring           >0.10 && <0.11
+- cryptonite           >0.22 && <0.31
+- bytestring           >0.10 && <0.12
 - base58-bytestring    >=0.1 && <0.2
 - animalcase           >0.1  && <0.2
 - generics-sop         >0.3  && <0.6
@@ -65,14 +65,14 @@ tests:
   tests:
     main:             Spec.hs
     source-dirs:
-    - tests 
+    - tests
     - src
     dependencies:
     - hspec-expectations-json >=1.0.0  && <1.1
     - hspec-expectations      >=0.8.2  && <0.9
-    - hspec-discover          >=2.4.4  && <2.9
+    - hspec-discover          >=2.4.4  && <2.12
     - hspec-contrib           >=0.4.0  && <0.6
-    - hspec                   >=2.4.4  && <2.9
+    - hspec                   >=2.4.4  && <2.12
     ghc-options:
     - -threaded
     - -rtsopts

--- a/packages/polkadot/web3-polkadot.cabal
+++ b/packages/polkadot/web3-polkadot.cabal
@@ -77,7 +77,7 @@ library
     , base58-bytestring ==0.1.*
     , bytestring >0.10 && <0.12
     , containers >0.6 && <0.7
-    , cryptonite >0.22 && <0.31
+    , crypton >=0.31 && <1.0
     , generics-sop >0.3 && <0.6
     , jsonrpc-tinyclient ==1.0.*
     , memory >0.14 && <0.19
@@ -154,7 +154,7 @@ test-suite tests
     , base58-bytestring ==0.1.*
     , bytestring >0.10 && <0.12
     , containers >0.6 && <0.7
-    , cryptonite >0.22 && <0.31
+    , crypton >=0.31 && <1.0
     , generics-sop >0.3 && <0.6
     , hspec >=2.4.4 && <2.12
     , hspec-contrib >=0.4.0 && <0.6

--- a/packages/polkadot/web3-polkadot.cabal
+++ b/packages/polkadot/web3-polkadot.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -71,24 +71,24 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      aeson >1.2 && <2.1
+      aeson >1.2 && <2.2
     , animalcase >0.1 && <0.2
-    , base >4.11 && <4.16
+    , base >4.11 && <4.19
     , base58-bytestring ==0.1.*
-    , bytestring >0.10 && <0.11
+    , bytestring >0.10 && <0.12
     , containers >0.6 && <0.7
-    , cryptonite >0.22 && <0.30
+    , cryptonite >0.22 && <0.31
     , generics-sop >0.3 && <0.6
     , jsonrpc-tinyclient ==1.0.*
-    , memory >0.14 && <0.17
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
     , microlens-mtl >0.2 && <0.3
     , microlens-th >0.4 && <0.5
-    , mtl >2.2 && <2.3
+    , mtl >2.2 && <2.4
     , parsec >3.0 && <3.2
     , scale ==1.0.*
-    , text >1.2 && <1.3
+    , text >1.2 && <2.1
     , web3-bignum ==1.0.*
     , web3-crypto ==1.0.*
   default-language: Haskell2010
@@ -148,29 +148,29 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >1.2 && <2.1
+      aeson >1.2 && <2.2
     , animalcase >0.1 && <0.2
-    , base >4.11 && <4.16
+    , base >4.11 && <4.19
     , base58-bytestring ==0.1.*
-    , bytestring >0.10 && <0.11
+    , bytestring >0.10 && <0.12
     , containers >0.6 && <0.7
-    , cryptonite >0.22 && <0.30
+    , cryptonite >0.22 && <0.31
     , generics-sop >0.3 && <0.6
-    , hspec >=2.4.4 && <2.9
+    , hspec >=2.4.4 && <2.12
     , hspec-contrib >=0.4.0 && <0.6
-    , hspec-discover >=2.4.4 && <2.9
+    , hspec-discover >=2.4.4 && <2.12
     , hspec-expectations >=0.8.2 && <0.9
     , hspec-expectations-json >=1.0.0 && <1.1
     , jsonrpc-tinyclient ==1.0.*
-    , memory >0.14 && <0.17
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
     , microlens-mtl >0.2 && <0.3
     , microlens-th >0.4 && <0.5
-    , mtl >2.2 && <2.3
+    , mtl >2.2 && <2.4
     , parsec >3.0 && <3.2
     , scale ==1.0.*
-    , text >1.2 && <1.3
+    , text >1.2 && <2.1
     , web3-bignum ==1.0.*
     , web3-crypto ==1.0.*
   default-language: Haskell2010

--- a/packages/provider/package.yaml
+++ b/packages/provider/package.yaml
@@ -11,16 +11,16 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.16
-- mtl                  >2.2  && <2.3
-- text                 >1.2  && <1.3
+- base                 >4.11 && <4.19
+- mtl                  >2.2  && <2.4
+- text                 >1.2  && <2.1
 - async                >2.1  && <2.3
 - network              >2.5  && <3.2
 - websockets           >0.10 && <0.13
 - exceptions           >0.8  && <0.11
 - http-client          >0.5  && <0.8
 - data-default         >0.7  && <0.8
-- transformers         >0.5  && <0.6
+- transformers         >0.5  && <0.7
 - jsonrpc-tinyclient   >=1.0 && <1.1
 
 ghc-options:

--- a/packages/provider/web3-provider.cabal
+++ b/packages/provider/web3-provider.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -32,14 +32,14 @@ library
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
       async >2.1 && <2.3
-    , base >4.11 && <4.16
+    , base >4.11 && <4.19
     , data-default >0.7 && <0.8
     , exceptions >0.8 && <0.11
     , http-client >0.5 && <0.8
     , jsonrpc-tinyclient ==1.0.*
-    , mtl >2.2 && <2.3
+    , mtl >2.2 && <2.4
     , network >2.5 && <3.2
-    , text >1.2 && <1.3
-    , transformers >0.5 && <0.6
+    , text >1.2 && <2.1
+    , transformers >0.5 && <0.7
     , websockets >0.10 && <0.13
   default-language: Haskell2010

--- a/packages/scale/package.yaml
+++ b/packages/scale/package.yaml
@@ -11,16 +11,16 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.16
-- text                 >1.2  && <1.3
+- base                 >4.11 && <4.19
+- text                 >1.2  && <2.1
 - cereal               >0.5  && <0.6
 - bitvec               >1.0  && <2.0
-- vector               >0.12 && <0.13
-- memory               >0.14 && <0.17
-- bytestring           >0.10 && <0.11
+- vector               >0.12 && <0.14
+- memory               >0.14 && <0.19
+- bytestring           >0.10 && <0.12
 - generics-sop         >0.3  && <0.6
 - data-default         >0.7  && <0.8
-- template-haskell     >2.11 && <2.18
+- template-haskell     >2.11 && <2.21
 
 ghc-options:
 - -funbox-strict-fields
@@ -55,14 +55,14 @@ tests:
   tests:
     main:             Spec.hs
     source-dirs:
-    - tests 
+    - tests
     - src
     dependencies:
-    - bytestring           >0.10    && <0.11
+    - bytestring           >0.10    && <0.12
     - hspec-expectations   >=0.8.2  && <0.9
-    - hspec-discover       >=2.4.4  && <2.9
+    - hspec-discover       >=2.4.4  && <2.12
     - hspec-contrib        >=0.4.0  && <0.6
-    - hspec                >=2.4.4  && <2.9
+    - hspec                >=2.4.4  && <2.12
     ghc-options:
     - -threaded
     - -rtsopts

--- a/packages/scale/scale.cabal
+++ b/packages/scale/scale.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -38,16 +38,16 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      base >4.11 && <4.16
+      base >4.11 && <4.19
     , bitvec >1.0 && <2.0
-    , bytestring >0.10 && <0.11
+    , bytestring >0.10 && <0.12
     , cereal >0.5 && <0.6
     , data-default >0.7 && <0.8
     , generics-sop >0.3 && <0.6
-    , memory >0.14 && <0.17
-    , template-haskell >2.11 && <2.18
-    , text >1.2 && <1.3
-    , vector >0.12 && <0.13
+    , memory >0.14 && <0.19
+    , template-haskell >2.11 && <2.21
+    , text >1.2 && <2.1
+    , vector >0.12 && <0.14
   default-language: Haskell2010
 
 test-suite tests
@@ -71,18 +71,18 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >4.11 && <4.16
+      base >4.11 && <4.19
     , bitvec >1.0 && <2.0
-    , bytestring >0.10 && <0.11
+    , bytestring >0.10 && <0.12
     , cereal >0.5 && <0.6
     , data-default >0.7 && <0.8
     , generics-sop >0.3 && <0.6
-    , hspec >=2.4.4 && <2.9
+    , hspec >=2.4.4 && <2.12
     , hspec-contrib >=0.4.0 && <0.6
-    , hspec-discover >=2.4.4 && <2.9
+    , hspec-discover >=2.4.4 && <2.12
     , hspec-expectations >=0.8.2 && <0.9
-    , memory >0.14 && <0.17
-    , template-haskell >2.11 && <2.18
-    , text >1.2 && <1.3
-    , vector >0.12 && <0.13
+    , memory >0.14 && <0.19
+    , template-haskell >2.11 && <2.21
+    , text >1.2 && <2.1
+    , vector >0.12 && <0.14
   default-language: Haskell2010

--- a/packages/solidity/package.yaml
+++ b/packages/solidity/package.yaml
@@ -11,21 +11,21 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.16
-- text                 >1.2  && <1.3
-- aeson                >1.2  && <2.1
+- base                 >4.11 && <4.19
+- text                 >1.2  && <2.1
+- aeson                >1.2  && <2.2
 - cereal               >0.5  && <0.6
-- memory               >0.14 && <0.17
+- memory               >0.14 && <0.19
 - memory-hexstring     >=1.0 && <1.1
 - tagged               >0.8  && <0.9
 - parsec               >3.1  && <3.2
 - basement             >0.0  && <0.1
-- OneTuple             >0.2  && <0.4
+- OneTuple             >0.2  && <0.5
 - microlens            >0.4  && <0.5
-- bytestring           >0.10 && <0.11
+- bytestring           >0.10 && <0.12
 - generics-sop         >0.3  && <0.6
 - data-default         >0.7  && <0.8
-- template-haskell     >2.11 && <2.18
+- template-haskell     >2.11 && <2.21
 - web3-crypto          >=1.0 && <1.1
 
 ghc-options:
@@ -61,13 +61,13 @@ tests:
   tests:
     main:             Spec.hs
     source-dirs:
-    - tests 
+    - tests
     - src
     dependencies:
     - hspec-expectations   >=0.8.2  && <0.9
-    - hspec-discover       >=2.4.4  && <2.9
+    - hspec-discover       >=2.4.4  && <2.12
     - hspec-contrib        >=0.4.0  && <0.6
-    - hspec                >=2.4.4  && <2.9
+    - hspec                >=2.4.4  && <2.12
     ghc-options:
     - -threaded
     - -rtsopts

--- a/packages/solidity/src/Data/Solidity/Prim/Bytes.hs
+++ b/packages/solidity/src/Data/Solidity/Prim/Bytes.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- |
 -- Module      :  Data.Solidity.Prim.Bytes

--- a/packages/solidity/src/Data/Solidity/Prim/Int.hs
+++ b/packages/solidity/src/Data/Solidity/Prim/Int.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 -- |
 -- Module      :  Data.Solidity.Prim.Int

--- a/packages/solidity/web3-solidity.cabal
+++ b/packages/solidity/web3-solidity.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -46,21 +46,21 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      OneTuple >0.2 && <0.4
-    , aeson >1.2 && <2.1
-    , base >4.11 && <4.16
+      OneTuple >0.2 && <0.5
+    , aeson >1.2 && <2.2
+    , base >4.11 && <4.19
     , basement >0.0 && <0.1
-    , bytestring >0.10 && <0.11
+    , bytestring >0.10 && <0.12
     , cereal >0.5 && <0.6
     , data-default >0.7 && <0.8
     , generics-sop >0.3 && <0.6
-    , memory >0.14 && <0.17
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
     , parsec >3.1 && <3.2
     , tagged >0.8 && <0.9
-    , template-haskell >2.11 && <2.18
-    , text >1.2 && <1.3
+    , template-haskell >2.11 && <2.21
+    , text >1.2 && <2.1
     , web3-crypto ==1.0.*
   default-language: Haskell2010
 
@@ -94,24 +94,24 @@ test-suite tests
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      OneTuple >0.2 && <0.4
-    , aeson >1.2 && <2.1
-    , base >4.11 && <4.16
+      OneTuple >0.2 && <0.5
+    , aeson >1.2 && <2.2
+    , base >4.11 && <4.19
     , basement >0.0 && <0.1
-    , bytestring >0.10 && <0.11
+    , bytestring >0.10 && <0.12
     , cereal >0.5 && <0.6
     , data-default >0.7 && <0.8
     , generics-sop >0.3 && <0.6
-    , hspec >=2.4.4 && <2.9
+    , hspec >=2.4.4 && <2.12
     , hspec-contrib >=0.4.0 && <0.6
-    , hspec-discover >=2.4.4 && <2.9
+    , hspec-discover >=2.4.4 && <2.12
     , hspec-expectations >=0.8.2 && <0.9
-    , memory >0.14 && <0.17
+    , memory >0.14 && <0.19
     , memory-hexstring ==1.0.*
     , microlens >0.4 && <0.5
     , parsec >3.1 && <3.2
     , tagged >0.8 && <0.9
-    , template-haskell >2.11 && <2.18
-    , text >1.2 && <1.3
+    , template-haskell >2.11 && <2.21
+    , text >1.2 && <2.1
     , web3-crypto ==1.0.*
   default-language: Haskell2010

--- a/packages/web3/package.yaml
+++ b/packages/web3/package.yaml
@@ -11,7 +11,7 @@ copyright:           "(c) Aleksandr Krupenkin 2016-2021"
 category:            Network
 
 dependencies:
-- base                 >4.11 && <4.16
+- base                 >4.11 && <4.19
 - web3-provider        >=1.0 && <1.1
 - web3-ethereum        >=1.0 && <1.1
 - web3-polkadot        >=1.0 && <1.1

--- a/packages/web3/web3.cabal
+++ b/packages/web3/web3.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -31,7 +31,7 @@ library
       src
   ghc-options: -funbox-strict-fields -Wduplicate-exports -Whi-shadowing -Widentities -Woverlapping-patterns -Wpartial-type-signatures -Wunrecognised-pragmas -Wtyped-holes -Wincomplete-patterns -Wincomplete-uni-patterns -Wmissing-fields -Wmissing-methods -Wmissing-exported-signatures -Wmissing-monadfail-instances -Wmissing-signatures -Wname-shadowing -Wunused-binds -Wunused-top-binds -Wunused-local-binds -Wunused-pattern-binds -Wunused-imports -Wunused-matches -Wunused-foralls -Wtabs
   build-depends:
-      base >4.11 && <4.16
+      base >4.11 && <4.19
     , web3-ethereum ==1.0.*
     , web3-polkadot ==1.0.*
     , web3-provider ==1.0.*

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
-resolver: lts-22.0
+resolver: lts-22.26
 
 # User packages to be built.
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
-resolver: lts-19.21
+resolver: lts-22.0
 
 # User packages to be built.
 packages:
@@ -18,10 +18,15 @@ packages:
 - 'examples/scale'
 - 'examples/polkadot'
 
+allow-newer: true
+
+allow-newer-deps:
+- animalcase
+
 # Extra package dependencies
 extra-deps:
 - animalcase-0.1.0.2@sha256:d7b80c3130c68d7ce8ddd9782588b2c4dd7da86461f302c54cc4acddf0902b51
-- relapse-1.0.0.1
+
 
 # Dependencies bounds
 pvp-bounds: both


### PR DESCRIPTION
LTS-22.26 is the latest Stackage resolver at the moment of this writing. Upgraded repo passes all tests on my machine and can deploy and interact with test test contract described on our Notion on the testnet, with a few adjustments due to changed data types.

Most of the work was made in this PR: https://github.com/airalab/hs-web3/pull/139, which uses LTS-22.0, but upgrading to LTS-22.26 was pretty straightforward.

I also took the liberty to replace the archived cryptonite library with crypton.